### PR TITLE
Fix/extends string for map

### DIFF
--- a/ts_json_subset/src/ident.rs
+++ b/ts_json_subset/src/ident.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
 
-#[derive(Debug, Clone, PartialEq, Eq, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, Display, Hash)]
 #[display("{0}")]
 pub struct TSIdent(String);
 

--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -43,6 +43,17 @@ pub struct ExtendsConstraint {
     pub types: Vec<TsType>,
 }
 
+impl ExtendsConstraint {
+    pub fn merge(&mut self, other: &ExtendsConstraint) {
+        other
+            .types
+            .iter()
+            .for_each(|ty| self.types.push(ty.clone()));
+        self.types.sort_by_key(|t| t.to_string());
+        self.types.dedup();
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Template)]
 #[template(source = "[ {{ inner_types|join(\", \") }} ]", ext = "txt")]
 /// A tuple represented as an array with positional types

--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -31,14 +31,17 @@ pub struct TypeParameters {
 }
 
 #[derive(Debug, Clone, PartialEq, Template)]
-#[template(source = "{{ identifier }} {{ constraint|display_opt -}}", ext = "txt")]
+#[template(
+    source = "{{ identifier -}} {{ constraint|display_opt -}}",
+    ext = "txt"
+)]
 pub struct TypeParameter {
     pub identifier: TSIdent,
     pub constraint: Option<ExtendsConstraint>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Template)]
-#[template(source = "extends {{ types|join(\", \") }}", ext = "txt")]
+#[template(source = " extends {{ types|join(\", \") }}", ext = "txt")]
 pub struct ExtendsConstraint {
     pub types: Vec<TsType>,
 }
@@ -333,12 +336,26 @@ pub mod tests {
                 ]
             }
             .to_string(),
-            "extends string, number",
+            " extends string, number",
         );
     }
 
     #[test]
     fn display_type_parameters() {
+        assert_eq!(
+            TypeParameters {
+                parameters: vec![TypeParameter {
+                    identifier: TSIdent::from_str("MyType").unwrap(),
+                    constraint: None,
+                },]
+            }
+            .to_string(),
+            "<MyType>",
+        )
+    }
+
+    #[test]
+    fn display_type_parameters_with_extends_clause() {
         assert_eq!(
             TypeParameters {
                 parameters: vec![TypeParameter {

--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -34,13 +34,13 @@ pub struct TypeParameters {
 #[template(source = "{{ identifier }} {{ constraint|display_opt -}}", ext = "txt")]
 pub struct TypeParameter {
     pub identifier: TSIdent,
-    pub constraint: Option<TypeConstraint>,
+    pub constraint: Option<ExtendsConstraint>,
 }
 
-#[derive(Debug, Clone, PartialEq, Display)]
-pub enum TypeConstraint {
-    #[display("extends {0}")]
-    Extends(TsType),
+#[derive(Default, Debug, Clone, PartialEq, Template)]
+#[template(source = "extends {{ types|join(\", \") }}", ext = "txt")]
+pub struct ExtendsConstraint {
+    pub types: Vec<TsType>,
 }
 
 #[derive(Debug, Clone, PartialEq, Template)]
@@ -315,11 +315,14 @@ pub mod tests {
     #[test]
     fn display_constraint() {
         assert_eq!(
-            TypeConstraint::Extends(TsType::PrimaryType(PrimaryType::Predefined(
-                PredefinedType::String
-            )))
+            ExtendsConstraint {
+                types: vec![
+                    TsType::PrimaryType(PrimaryType::Predefined(PredefinedType::String)),
+                    TsType::PrimaryType(PrimaryType::Predefined(PredefinedType::Number)),
+                ]
+            }
             .to_string(),
-            "extends string",
+            "extends string, number",
         );
     }
 
@@ -329,10 +332,12 @@ pub mod tests {
             TypeParameters {
                 parameters: vec![TypeParameter {
                     identifier: TSIdent::from_str("MyType").unwrap(),
-                    constraint: Some(TypeConstraint::Extends(TsType::PrimaryType(
-                        PrimaryType::Predefined(PredefinedType::String)
-                    ))),
-                }]
+                    constraint: Some(ExtendsConstraint {
+                        types: vec![TsType::PrimaryType(PrimaryType::Predefined(
+                            PredefinedType::String
+                        )),],
+                    })
+                },]
             }
             .to_string(),
             "<MyType extends string>",

--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -24,10 +24,23 @@ impl ArrayType {
 }
 
 #[derive(Debug, Clone, PartialEq, Template)]
-#[template(source = "<{{ identifiers|join(\", \") }}>", ext = "txt")]
+#[template(source = "<{{ parameters|join(\", \") }}>", ext = "txt")]
 /// A identifier list of generic parameters
 pub struct TypeParameters {
-    pub identifiers: Vec<TSIdent>,
+    pub parameters: Vec<TypeParameter>,
+}
+
+#[derive(Debug, Clone, PartialEq, Template)]
+#[template(source = "{{ identifier }} {{ constraint|display_opt -}}", ext = "txt")]
+pub struct TypeParameter {
+    pub identifier: TSIdent,
+    pub constraint: Option<TypeConstraint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Display)]
+pub enum TypeConstraint {
+    #[display("extends {0}")]
+    Extends(TsType),
 }
 
 #[derive(Debug, Clone, PartialEq, Template)]
@@ -297,5 +310,32 @@ pub mod tests {
             .to_string(),
             "{\n\t\n}",
         );
+    }
+
+    #[test]
+    fn display_constraint() {
+        assert_eq!(
+            TypeConstraint::Extends(TsType::PrimaryType(PrimaryType::Predefined(
+                PredefinedType::String
+            )))
+            .to_string(),
+            "extends string",
+        );
+    }
+
+    #[test]
+    fn display_type_parameters() {
+        assert_eq!(
+            TypeParameters {
+                parameters: vec![TypeParameter {
+                    identifier: TSIdent::from_str("MyType").unwrap(),
+                    constraint: Some(TypeConstraint::Extends(TsType::PrimaryType(
+                        PrimaryType::Predefined(PredefinedType::String)
+                    ))),
+                }]
+            }
+            .to_string(),
+            "<MyType extends string>",
+        )
     }
 }

--- a/typebinder/src/contexts/exporter.rs
+++ b/typebinder/src/contexts/exporter.rs
@@ -256,8 +256,12 @@ impl ExporterContext<'_> {
         let types: Vec<TsType> = variants
             .into_iter()
             .map(|variant| {
+                println!("exporting internal enum");
                 let variant_type = match (variant.style, variant.fields.as_slice()) {
-                    (Style::Unit, []) | (Style::Tuple, _) => None,
+                    (Style::Unit, []) | (Style::Tuple, _) => {
+                        println!("Not exporting variant {}", &variant.ident);
+                        None
+                    }
                     (Style::Newtype, [field]) => {
                         let (ty, mut entries) = self.solve_type(&TypeInfo {
                             generics,

--- a/typebinder/src/contexts/exporter.rs
+++ b/typebinder/src/contexts/exporter.rs
@@ -292,12 +292,8 @@ impl ExporterContext<'_> {
         let types: Vec<TsType> = variants
             .into_iter()
             .map(|variant| {
-                println!("exporting internal enum");
                 let variant_type = match (variant.style, variant.fields.as_slice()) {
-                    (Style::Unit, []) | (Style::Tuple, _) => {
-                        println!("Not exporting variant {}", &variant.ident);
-                        None
-                    }
+                    (Style::Unit, []) | (Style::Tuple, _) => None,
                     (Style::Newtype, [field]) => {
                         let mut solved = self.solve_type(&TypeInfo {
                             generics,

--- a/typebinder/src/pipeline/module_step.rs
+++ b/typebinder/src/pipeline/module_step.rs
@@ -7,7 +7,7 @@ use crate::{
     macros::context::MacroSolvingContext,
     path_mapper::PathMapper,
     step_spawner::PipelineStepSpawner,
-    type_solving::{generic_constraints::GenericConstraints, ImportEntry},
+    type_solving::ImportEntry,
 };
 use indexmap::{IndexMap, IndexSet};
 use result::prelude::*;
@@ -147,7 +147,6 @@ impl ModuleStep {
         });
 
         let mut imports: Vec<ImportEntry> = Vec::new();
-        let mut constraints = GenericConstraints::default();
 
         let mut statements: Vec<(usize, Vec<ExportStatement>)> = type_export_statements
             .chain(container_statements)
@@ -156,7 +155,6 @@ impl ModuleStep {
             .into_iter()
             .map(|(index, mut solved)| {
                 imports.append(&mut solved.import_entries);
-                constraints.merge(solved.generic_constraints);
                 (index, solved.inner)
             })
             .collect();

--- a/typebinder/src/type_solving/generic_constraints.rs
+++ b/typebinder/src/type_solving/generic_constraints.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use ts_json_subset::{
+    ident::TSIdent,
+    types::{ExtendsConstraint, TsType},
+};
+
+#[derive(Debug, Default)]
+pub struct GenericConstraints(HashMap<TSIdent, ExtendsConstraint>);
+
+impl GenericConstraints {
+    pub fn add_extends_constraint(&mut self, ident: TSIdent, ts_type: TsType) {
+        let constraints = self.0.entry(ident).or_default();
+        constraints.types.push(ts_type);
+    }
+
+    pub fn merge(&mut self, other_constraints: GenericConstraints) {
+        other_constraints
+            .0
+            .iter()
+            .for_each(|(ts_ident, constraint)| {
+                let entry = self.0.entry(ts_ident.clone()).or_default();
+                entry.merge(constraint);
+            });
+    }
+}

--- a/typebinder/src/type_solving/generic_constraints.rs
+++ b/typebinder/src/type_solving/generic_constraints.rs
@@ -23,4 +23,8 @@ impl GenericConstraints {
                 entry.merge(constraint);
             });
     }
+
+    pub fn get_constraints(&self, ident: &TSIdent) -> Option<ExtendsConstraint> {
+        self.0.get(ident).cloned()
+    }
 }

--- a/typebinder/src/type_solving/mod.rs
+++ b/typebinder/src/type_solving/mod.rs
@@ -6,6 +6,7 @@ use std::{rc::Rc, sync::Arc};
 use ts_json_subset::types::{PropertyName, PropertySignature, TsType, TypeMember};
 
 pub mod fn_solver;
+pub mod generic_constraints;
 pub mod member_info;
 pub mod result;
 pub mod solvers;
@@ -54,14 +55,13 @@ pub trait TypeSolver {
     ) -> SolverResult<TypeMember, TsExportError> {
         let result = self.solve_as_type(solving_context, &solver_info.as_type_info());
         match result {
-            SolverResult::Solved(inner_type, imports) => SolverResult::Solved(
+            SolverResult::Solved(solved) => SolverResult::Solved(solved.map(|inner_type| {
                 TypeMember::PropertySignature(PropertySignature {
                     inner_type,
                     name: PropertyName::from(solver_info.name.clone()),
                     optional: false,
-                }),
-                imports,
-            ),
+                })
+            })),
             SolverResult::Error(e) => SolverResult::Error(e),
             SolverResult::Continue => SolverResult::Continue,
         }

--- a/typebinder/src/type_solving/result.rs
+++ b/typebinder/src/type_solving/result.rs
@@ -1,25 +1,52 @@
-use ts_json_subset::types::{TsType, TypeMember};
+use super::{generic_constraints::GenericConstraints, ImportEntry};
 
-use crate::error::TsExportError;
+#[derive(Default)]
+pub struct Solved<T> {
+    pub inner: T,
+    pub import_entries: Vec<ImportEntry>,
+    pub generic_constraints: GenericConstraints,
+}
 
-use super::ImportEntry;
+impl<T> Solved<T> {
+    pub fn new(inner: T) -> Self {
+        Solved {
+            inner,
+            import_entries: Vec::new(),
+            generic_constraints: GenericConstraints::default(),
+        }
+    }
 
-/// The result of a TypeSolver. See the explanation there.
+    pub fn map<U, F: FnOnce(T) -> U>(self, mapper: F) -> Solved<U> {
+        let Solved {
+            inner,
+            import_entries,
+            generic_constraints,
+        } = self;
+        Solved {
+            inner: mapper(inner),
+            import_entries,
+            generic_constraints,
+        }
+    }
+}
+
+/// The result of a TypeSolver. See the explanation on each variants.
 pub enum SolverResult<T, E> {
     /// The solver could not process the given type info
     Continue,
     /// The solver correctly processed the input type
-    Solved(T, Vec<ImportEntry>),
+    Solved(Solved<T>),
     /// The solver tried to process the input type, but it failed to do so
     Error(E),
 }
 
+/*
 impl From<Result<(TsType, Vec<ImportEntry>), TsExportError>>
     for SolverResult<TsType, TsExportError>
 {
     fn from(result: Result<(TsType, Vec<ImportEntry>), TsExportError>) -> Self {
         match result {
-            Ok((ty, imports)) => SolverResult::Solved(ty, imports),
+            Ok((ty, import_entries)) => SolverResult::Solved(Solved { inner: ty, import_entriess),
             Err(e) => SolverResult::Error(e),
         }
     }
@@ -35,3 +62,4 @@ impl From<Result<(TypeMember, Vec<ImportEntry>), TsExportError>>
         }
     }
 }
+*/

--- a/typebinder/src/type_solving/solvers/array.rs
+++ b/typebinder/src/type_solving/solvers/array.rs
@@ -1,7 +1,7 @@
 use crate::{
     contexts::exporter::ExporterContext,
     error::TsExportError,
-    type_solving::{SolverResult, TypeInfo, TypeSolver},
+    type_solving::{result::Solved, SolverResult, TypeInfo, TypeSolver},
 };
 use syn::Type;
 use ts_json_subset::types::{ArrayType, PrimaryType, TsType};
@@ -31,12 +31,17 @@ impl TypeSolver for ArraySolver {
         };
 
         match result {
-            Ok((TsType::PrimaryType(primary), imports)) => SolverResult::Solved(
-                TsType::PrimaryType(PrimaryType::ArrayType(ArrayType::new(primary))),
-                imports,
-            ),
+            Ok(Solved {
+                inner: TsType::PrimaryType(primary),
+                import_entries,
+                generic_constraints,
+            }) => SolverResult::Solved(Solved {
+                inner: TsType::PrimaryType(PrimaryType::ArrayType(ArrayType::new(primary))),
+                import_entries,
+                generic_constraints,
+            }),
             // TODO: This is maybe unreachable ?
-            Ok((ts_ty, _imports)) => SolverResult::Error(TsExportError::UnexpectedType(ts_ty)),
+            Ok(Solved { inner, .. }) => SolverResult::Error(TsExportError::UnexpectedType(inner)),
             Err(e) => SolverResult::Error(e),
         }
     }

--- a/typebinder/src/type_solving/solvers/chrono.rs
+++ b/typebinder/src/type_solving/solvers/chrono.rs
@@ -4,7 +4,7 @@ use super::path::PathSolver;
 use crate::{
     contexts::exporter::ExporterContext,
     error::TsExportError,
-    type_solving::fn_solver::AsFnSolver,
+    type_solving::{fn_solver::AsFnSolver, result::Solved},
     type_solving::{SolverResult, TypeInfo, TypeSolver, TypeSolverExt},
 };
 
@@ -17,10 +17,9 @@ fn solve_datetime(
     _solving_context: &ExporterContext,
     _solver_info: &TypeInfo,
 ) -> SolverResult<TsType, TsExportError> {
-    SolverResult::Solved(
-        TsType::PrimaryType(PrimaryType::Predefined(PredefinedType::String)),
-        Vec::new(),
-    )
+    SolverResult::Solved(Solved::new(TsType::PrimaryType(PrimaryType::Predefined(
+        PredefinedType::String,
+    ))))
 }
 
 impl Default for ChronoSolver {

--- a/typebinder/src/type_solving/solvers/collections.rs
+++ b/typebinder/src/type_solving/solvers/collections.rs
@@ -75,7 +75,6 @@ fn solve_map(
                         TSIdent::from_str(&format!("{}", first)).unwrap(),
                         TsType::PrimaryType(PrimaryType::Predefined(PredefinedType::String)),
                     );
-                    println!("constraints for map {:?}", solved.generic_constraints);
                     SolverResult::Solved(solved)
                 }
                 Err(e) => SolverResult::Error(e),

--- a/typebinder/src/type_solving/solvers/collections.rs
+++ b/typebinder/src/type_solving/solvers/collections.rs
@@ -10,7 +10,7 @@ use crate::{
 use syn::Type;
 use ts_json_subset::{
     ident::TSIdent,
-    types::{ArrayType, PrimaryType, TsType, TypeArguments, TypeReference},
+    types::{ArrayType, PredefinedType, PrimaryType, TsType, TypeArguments, TypeReference},
 };
 
 use super::path::PathSolver;
@@ -61,22 +61,21 @@ fn solve_map(
         Type::Path(ty) => {
             let segment = ty.path.segments.last().expect("Empty path");
             match solve_segment_generics(solving_context, generics, segment) {
-                Ok(Solved {
-                    inner,
-                    import_entries,
-                    generic_constraints,
-                }) => {
-                    let mut solved = Solved::new(TsType::PrimaryType(PrimaryType::TypeReference(
-                        TypeReference {
+                Ok(solved) => {
+                    let first = solved.inner[0].clone();
+                    let mut solved = solved.map(|inner| {
+                        TsType::PrimaryType(PrimaryType::TypeReference(TypeReference {
                             name: TSIdent::from_str("Record").unwrap(),
                             args: Some(TypeArguments {
                                 types: vec![inner[0].clone().into(), inner[1].clone().into()],
                             }),
-                        },
-                    )));
-                    solved.import_entries = import_entries;
-                    solved.generic_constraints.merge(generic_constraints);
-                    // TODO: Add constraint on inner[0]
+                        }))
+                    });
+                    solved.generic_constraints.add_extends_constraint(
+                        TSIdent::from_str(&format!("{}", first)).unwrap(),
+                        TsType::PrimaryType(PrimaryType::Predefined(PredefinedType::String)),
+                    );
+                    println!("constraints for map {:?}", solved.generic_constraints);
                     SolverResult::Solved(solved)
                 }
                 Err(e) => SolverResult::Error(e),

--- a/typebinder/src/type_solving/solvers/generics.rs
+++ b/typebinder/src/type_solving/solvers/generics.rs
@@ -9,7 +9,7 @@ use ts_json_subset::{
 use crate::{
     contexts::exporter::ExporterContext,
     error::TsExportError,
-    type_solving::{SolverResult, TypeInfo, TypeSolver},
+    type_solving::{result::Solved, SolverResult, TypeInfo, TypeSolver},
 };
 
 /// A solver that tries to find the ident of the type in the generics of the parent type
@@ -41,13 +41,12 @@ impl TypeSolver for GenericsSolver {
         };
 
         match ty {
-            Some(ty) => SolverResult::Solved(
-                TsType::PrimaryType(PrimaryType::TypeReference(TypeReference {
+            Some(ty) => SolverResult::Solved(Solved::new(TsType::PrimaryType(
+                PrimaryType::TypeReference(TypeReference {
                     args: None,
                     name: TSIdent::from_str(&ty.ident.to_string()).unwrap(),
-                })),
-                Vec::new(),
-            ),
+                }),
+            ))),
             _ => SolverResult::Continue,
         }
     }

--- a/typebinder/src/type_solving/solvers/primitives.rs
+++ b/typebinder/src/type_solving/solvers/primitives.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     contexts::exporter::ExporterContext,
     error::TsExportError,
-    type_solving::fn_solver::AsFnSolver,
+    type_solving::{fn_solver::AsFnSolver, result::Solved},
     type_solving::{SolverResult, TypeInfo, TypeSolver, TypeSolverExt},
 };
 use ts_json_subset::types::{PredefinedType, PrimaryType, TsType};
@@ -19,10 +19,9 @@ fn solve_number(
     _exporter: &ExporterContext,
     _solver_info: &TypeInfo,
 ) -> SolverResult<TsType, TsExportError> {
-    SolverResult::Solved(
+    SolverResult::Solved(Solved::new(
         PrimaryType::Predefined(PredefinedType::Number).into(),
-        Vec::new(),
-    )
+    ))
 }
 
 impl Default for PrimitivesSolver {
@@ -30,19 +29,17 @@ impl Default for PrimitivesSolver {
         let solver_number = solve_number.fn_solver().into_rc();
 
         let solver_string = (|_: &ExporterContext, _: &TypeInfo| {
-            SolverResult::Solved(
+            SolverResult::Solved(Solved::new(
                 PrimaryType::Predefined(PredefinedType::String).into(),
-                Vec::new(),
-            )
+            ))
         })
         .fn_solver()
         .into_rc();
 
         let solver_bool = (|_: &ExporterContext, _: &TypeInfo| {
-            SolverResult::Solved(
+            SolverResult::Solved(Solved::new(
                 PrimaryType::Predefined(PredefinedType::Boolean).into(),
-                Vec::new(),
-            )
+            ))
         })
         .fn_solver()
         .into_rc();

--- a/typebinder/src/type_solving/solvers/reference.rs
+++ b/typebinder/src/type_solving/solvers/reference.rs
@@ -23,7 +23,7 @@ impl TypeSolver for ReferenceSolver {
             Type::Reference(ty) => {
                 let ty = ty.elem.as_ref();
                 match solving_context.solve_type(&TypeInfo { generics, ty }) {
-                    Ok((t, imports)) => SolverResult::Solved(t, imports),
+                    Ok(solved) => SolverResult::Solved(solved),
                     Err(e) => SolverResult::Error(e),
                 }
             }

--- a/typebinder/src/type_solving/solvers/serde_json_value.rs
+++ b/typebinder/src/type_solving/solvers/serde_json_value.rs
@@ -3,7 +3,7 @@ use ts_json_subset::types::{PredefinedType, PrimaryType, TsType};
 use crate::{
     contexts::exporter::ExporterContext,
     error::TsExportError,
-    type_solving::fn_solver::AsFnSolver,
+    type_solving::{fn_solver::AsFnSolver, result::Solved},
     type_solving::{SolverResult, TypeInfo, TypeSolver, TypeSolverExt},
 };
 
@@ -19,10 +19,9 @@ fn solve_serde_json_value(
     _exporter_context: &ExporterContext,
     _type_info: &TypeInfo,
 ) -> SolverResult<TsType, TsExportError> {
-    SolverResult::Solved(
-        TsType::PrimaryType(PrimaryType::Predefined(PredefinedType::Any)),
-        Vec::new(),
-    )
+    SolverResult::Solved(Solved::new(TsType::PrimaryType(PrimaryType::Predefined(
+        PredefinedType::Any,
+    ))))
 }
 
 impl Default for SerdeJsonValueSolver {

--- a/typebinder_test_suite/src/models.rs
+++ b/typebinder_test_suite/src/models.rs
@@ -99,3 +99,16 @@ enum InternallyTagged {
     B(Person),
     D { age: u32, name: String },
 }
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum A {
+    AllDays,
+    OneDay(B),
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum B {
+    Monday,
+    Tuesday,
+}

--- a/typebinder_test_suite/src/models.rs
+++ b/typebinder_test_suite/src/models.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -111,4 +111,9 @@ pub enum A {
 pub enum B {
     Monday,
     Tuesday,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MyCustomMap<T> {
+    the_map: HashMap<T, u32>,
 }


### PR DESCRIPTION
Fixes #25 . 

* Adds support for "extends XXX" in `ts_json_subset`
* Massive changes to refactor the tuple "(type, import entries)" into the `Solved<T>` type and all its usage throughout the codebase
* Change the "collection" solver (that solves `HashMap`) to add an `extends string` clause on the `Key` generic of the `Record`