### PR TITLE
Fix ArrayType wrong representation and array+collection solvers

### DIFF
--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -26,12 +26,15 @@ pub enum ArrayTypeInner {
 impl ArrayType {
     pub fn new(ts_type: TsType) -> Self {
         ArrayType {
-            inner_type: match ts_type {
-                TsType::PrimaryType(primary) => Box::new(ArrayTypeInner::Primary(primary)),
-                _ => Box::new(ArrayTypeInner::Parenthesized(ParenthesizedType {
-                    inner: Box::new(ts_type),
-                })),
-            },
+            inner_type: Box::new(match ts_type {
+                TsType::PrimaryType(primary) => ArrayTypeInner::Primary(primary),
+                TsType::ParenthesizedType(paren) => ArrayTypeInner::Parenthesized(paren),
+                TsType::IntersectionType(_) | TsType::UnionType(_) => {
+                    ArrayTypeInner::Parenthesized(ParenthesizedType {
+                        inner: Box::new(ts_type),
+                    })
+                }
+            }),
         }
     }
 }

--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -12,13 +12,26 @@ use from_variants::FromVariants;
 #[template(source = "{{ inner_type }}[]", ext = "txt")]
 /// A generic TS array
 pub struct ArrayType {
-    pub inner_type: Box<PrimaryType>,
+    pub inner_type: Box<ArrayTypeInner>,
+}
+
+#[derive(Debug, Clone, PartialEq, Display)]
+pub enum ArrayTypeInner {
+    #[display("{0}")]
+    Primary(PrimaryType),
+    #[display("{0}")]
+    Parenthesized(ParenthesizedType),
 }
 
 impl ArrayType {
-    pub fn new(primary: PrimaryType) -> Self {
+    pub fn new(ts_type: TsType) -> Self {
         ArrayType {
-            inner_type: Box::new(primary),
+            inner_type: match ts_type {
+                TsType::PrimaryType(primary) => Box::new(ArrayTypeInner::Primary(primary)),
+                _ => Box::new(ArrayTypeInner::Parenthesized(ParenthesizedType {
+                    inner: Box::new(ts_type),
+                })),
+            },
         }
     }
 }

--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -326,7 +326,10 @@ pub mod tests {
     #[test]
     fn display_array_type() {
         assert_eq!(
-            ArrayType::new(PrimaryType::Predefined(PredefinedType::Any)).to_string(),
+            ArrayType::new(TsType::PrimaryType(PrimaryType::Predefined(
+                PredefinedType::Any
+            )))
+            .to_string(),
             "any[]"
         );
     }

--- a/typebinder/src/type_solving/solvers/array.rs
+++ b/typebinder/src/type_solving/solvers/array.rs
@@ -32,16 +32,14 @@ impl TypeSolver for ArraySolver {
 
         match result {
             Ok(Solved {
-                inner: TsType::PrimaryType(primary),
+                inner,
                 import_entries,
                 generic_constraints,
             }) => SolverResult::Solved(Solved {
-                inner: TsType::PrimaryType(PrimaryType::ArrayType(ArrayType::new(primary))),
+                inner: TsType::PrimaryType(PrimaryType::ArrayType(ArrayType::new(inner))),
                 import_entries,
                 generic_constraints,
             }),
-            // TODO: This is maybe unreachable ?
-            Ok(Solved { inner, .. }) => SolverResult::Error(TsExportError::UnexpectedType(inner)),
             Err(e) => SolverResult::Error(e),
         }
     }

--- a/typebinder/src/type_solving/solvers/collections.rs
+++ b/typebinder/src/type_solving/solvers/collections.rs
@@ -32,19 +32,16 @@ fn solve_seq(
             let segment = ty.path.segments.last().expect("Empty path");
             match solve_segment_generics(solving_context, generics, segment) {
                 Ok(Solved {
-                    inner: types,
+                    inner,
                     import_entries,
                     generic_constraints,
-                }) => match &types[0] {
-                    TsType::PrimaryType(prim) => SolverResult::Solved(Solved {
-                        inner: TsType::PrimaryType(PrimaryType::ArrayType(ArrayType::new(
-                            prim.clone(),
-                        ))),
-                        import_entries,
-                        generic_constraints,
-                    }),
-                    _ => SolverResult::Error(TsExportError::UnexpectedType(types[0].clone())),
-                },
+                }) => SolverResult::Solved(Solved {
+                    inner: TsType::PrimaryType(PrimaryType::ArrayType(ArrayType::new(
+                        inner[0].clone(),
+                    ))),
+                    import_entries,
+                    generic_constraints,
+                }),
                 Err(e) => SolverResult::Error(e),
             }
         }

--- a/typebinder_test_suite/src/models.rs
+++ b/typebinder_test_suite/src/models.rs
@@ -117,3 +117,14 @@ pub enum B {
 pub struct MyCustomMap<T> {
     the_map: HashMap<T, u32>,
 }
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum StringOrNumber {
+    String(String),
+    Number(f64),
+}
+
+type VecOfOptionalNumbers = Vec<Option<u32>>;
+type OptionalStringOrNumber = Option<StringOrNumber>;
+type VecOfOptionalStringOrNumbers = Vec<Option<StringOrNumber>>;


### PR DESCRIPTION
ArrayType used to allow only `PrimaryType` as its inner type, meaning it wasnt possible to represent types such as : 

```
type MyType = (A|B)[];
type MyType = (A&B)[];
``` 

which are in fact valid TypeScript. 

`ArrayType` should be either a `PrimaryType` or a `ParenthesizedType` to allow for that representation. Changing this fixes both the `Array` and the `Collections` solvers, allowing for representation of Rust types such as `Vec<Option<T>>`.

* All collections are supported (Vec, VecDeque, HashSet etc...) 
* All types that are union types (because they were #[serde(untagged)] for example) are now supported as well

  

