### PR TITLE
Fix unnecessary quoting for property names

### DIFF
--- a/ts_json_subset/src/declarations/const_enum.rs
+++ b/ts_json_subset/src/declarations/const_enum.rs
@@ -1,11 +1,11 @@
-use crate::{common::StringLiteral, ident::TSIdent};
+use crate::{common::StringLiteral, ident::StrictTSIdent};
 use askama::Template;
 
 #[derive(Debug, Clone, PartialEq, Template)]
 #[template(source = "const enum {{ ident }} {{ body }}", ext = "txt")]
 /// A const enum with string literals (TS numeric const enum offer no advantage, consider using union types instead)
 pub struct ConstEnumDeclaration {
-    pub ident: TSIdent,
+    pub ident: StrictTSIdent,
     pub body: ConstEnumBody,
 }
 
@@ -20,7 +20,7 @@ pub struct ConstEnumBody {
 #[template(source = "{{ ident }} = {{ value }}", ext = "txt")]
 /// A const enum variant with string literal
 pub struct ConstEnumVariant {
-    pub ident: TSIdent,
+    pub ident: StrictTSIdent,
     pub value: StringLiteral,
 }
 
@@ -34,11 +34,11 @@ pub mod tests {
         ConstEnumBody {
             variants: vec![
                 ConstEnumVariant {
-                    ident: TSIdent::from_str("One").unwrap(),
+                    ident: StrictTSIdent::from_str("One").unwrap(),
                     value: StringLiteral::from_raw("one"),
                 },
                 ConstEnumVariant {
-                    ident: TSIdent::from_str("Two").unwrap(),
+                    ident: StrictTSIdent::from_str("Two").unwrap(),
                     value: StringLiteral::from_raw("two"),
                 },
             ],
@@ -49,7 +49,7 @@ pub mod tests {
     fn display_const_enum_declaration() {
         assert_eq!(
             ConstEnumDeclaration {
-                ident: TSIdent::from_str("MyEnum").unwrap(),
+                ident: StrictTSIdent::from_str("MyEnum").unwrap(),
                 body: build_dummy_enum_body()
             }
             .to_string(),
@@ -69,7 +69,7 @@ pub mod tests {
     fn display_const_enum_variant() {
         assert_eq!(
             ConstEnumVariant {
-                ident: TSIdent::from_str("MyVariant").unwrap(),
+                ident: StrictTSIdent::from_str("MyVariant").unwrap(),
                 value: StringLiteral::from_raw("TheValue"),
             }
             .to_string(),

--- a/ts_json_subset/src/declarations/interface.rs
+++ b/ts_json_subset/src/declarations/interface.rs
@@ -1,5 +1,5 @@
 use crate::types::{ObjectType, TypeParameters, TypeReference};
-use crate::{common::filters, ident::TSIdent};
+use crate::{common::filters, ident::StrictTSIdent};
 use askama::Template;
 
 #[derive(Debug, Clone, PartialEq, Template)]
@@ -23,7 +23,7 @@ pub struct InterfaceExtendsClause {
 /// An interface declaration,
 /// supports generics parameters and extends
 pub struct InterfaceDeclaration {
-    pub ident: TSIdent,
+    pub ident: StrictTSIdent,
     pub type_params: Option<TypeParameters>,
     pub extends_clause: Option<InterfaceExtendsClause>,
     pub obj_type: ObjectType,
@@ -45,11 +45,11 @@ pub mod tests {
             InterfaceTypeList {
                 identifiers: vec![
                     TypeReference {
-                        name: TSIdent::from_str("Test").unwrap(),
+                        name: StrictTSIdent::from_str("Test").unwrap(),
                         args: None,
                     },
                     TypeReference {
-                        name: TSIdent::from_str("TestOther").unwrap(),
+                        name: StrictTSIdent::from_str("TestOther").unwrap(),
                         args: None,
                     }
                 ],
@@ -66,11 +66,11 @@ pub mod tests {
                 type_list: InterfaceTypeList {
                     identifiers: vec![
                         TypeReference {
-                            name: TSIdent::from_str("Test").unwrap(),
+                            name: StrictTSIdent::from_str("Test").unwrap(),
                             args: None,
                         },
                         TypeReference {
-                            name: TSIdent::from_str("TestOther").unwrap(),
+                            name: StrictTSIdent::from_str("TestOther").unwrap(),
                             args: None,
                         }
                     ],
@@ -85,7 +85,7 @@ pub mod tests {
     fn display_interface_declaration() {
         assert_eq!(
             InterfaceDeclaration {
-                ident: TSIdent::from_str("MyInterface").unwrap(),
+                ident: StrictTSIdent::from_str("MyInterface").unwrap(),
                 extends_clause: None,
                 type_params: None,
                 obj_type: ObjectType {
@@ -98,7 +98,7 @@ pub mod tests {
 
         assert_eq!(
             InterfaceDeclaration {
-                ident: TSIdent::from_str("MyInterface").unwrap(),
+                ident: StrictTSIdent::from_str("MyInterface").unwrap(),
                 extends_clause: None,
                 type_params: None,
                 obj_type: ObjectType {

--- a/ts_json_subset/src/declarations/reexport.rs
+++ b/ts_json_subset/src/declarations/reexport.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 
-use crate::ident::TSIdent;
+use crate::ident::StrictTSIdent;
 
 #[derive(Debug, Clone, PartialEq, Eq, Template)]
 #[template(source = r#"{ {{ reexports|join(", ") }} }"#, ext = "txt")]
@@ -11,8 +11,8 @@ pub struct ReexportDeclaration {
 #[derive(Debug, Clone, PartialEq, Eq, Template)]
 #[template(source = r#"{{ scope }} as {{ export_as }}"#, ext = "txt")]
 pub struct ReexportClause {
-    pub scope: TSIdent,
-    pub export_as: TSIdent,
+    pub scope: StrictTSIdent,
+    pub export_as: StrictTSIdent,
 }
 
 #[cfg(test)]
@@ -24,8 +24,8 @@ pub mod tests {
     pub fn should_reexport() {
         assert_eq!(
             ReexportClause {
-                scope: TSIdent::from_str("ThisType").unwrap(),
-                export_as: TSIdent::from_str("ThatType").unwrap(),
+                scope: StrictTSIdent::from_str("ThisType").unwrap(),
+                export_as: StrictTSIdent::from_str("ThatType").unwrap(),
             }
             .to_string(),
             "ThisType as ThatType",

--- a/ts_json_subset/src/declarations/type_alias.rs
+++ b/ts_json_subset/src/declarations/type_alias.rs
@@ -1,5 +1,5 @@
 use crate::types::{TsType, TypeParameters};
-use crate::{common::filters, ident::TSIdent};
+use crate::{common::filters, ident::StrictTSIdent};
 use askama::Template;
 
 #[derive(Debug, Clone, PartialEq, Template)]
@@ -10,7 +10,7 @@ use askama::Template;
 /// A type alias declaration,
 /// supports generics parameters
 pub struct TypeAliasDeclaration {
-    pub ident: TSIdent,
+    pub ident: StrictTSIdent,
     pub type_params: Option<TypeParameters>,
     pub inner_type: TsType,
 }
@@ -27,7 +27,7 @@ pub mod tests {
     fn display_type_alias_declaration() {
         assert_eq!(
             TypeAliasDeclaration {
-                ident: TSIdent::from_str("MyType").unwrap(),
+                ident: StrictTSIdent::from_str("MyType").unwrap(),
                 type_params: None,
                 inner_type: TsType::PrimaryType(PrimaryType::Predefined(PredefinedType::Any)),
             }

--- a/ts_json_subset/src/ident.rs
+++ b/ts_json_subset/src/ident.rs
@@ -15,7 +15,6 @@ pub struct TSIdent(String);
 /// A TS identifier that is also checked for reserved keywords
 pub struct StrictTSIdent(TSIdent);
 
-
 lazy_static! {
     static ref REGEX_TS_IDENT: Regex = Regex::new("^[a-zA-Z_$]+[a-zA-Z1-9_$]*$").unwrap();
     static ref RESERVED: [&'static str; 36] = [
@@ -101,14 +100,8 @@ pub mod tests {
 
     #[test]
     pub fn should_work_when_ident_is_reserved_keyword() {
-        assert_eq!(
-            TSIdent::from_str("void"),
-            Ok(TSIdent("void".to_string()))
-        );
-        assert_eq!(
-            TSIdent::from_str("break"),
-            Ok(TSIdent("break".to_string()))
-        );
+        assert_eq!(TSIdent::from_str("void"), Ok(TSIdent("void".to_string())));
+        assert_eq!(TSIdent::from_str("break"), Ok(TSIdent("break".to_string())));
     }
 
     #[test]

--- a/ts_json_subset/src/ident.rs
+++ b/ts_json_subset/src/ident.rs
@@ -7,7 +7,14 @@ use regex::Regex;
 
 #[derive(Debug, Clone, PartialEq, Eq, Display, Hash)]
 #[display("{0}")]
+// A valid TS identifier
 pub struct TSIdent(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Display, Hash)]
+#[display("{0}")]
+/// A TS identifier that is also checked for reserved keywords
+pub struct StrictTSIdent(TSIdent);
+
 
 lazy_static! {
     static ref REGEX_TS_IDENT: Regex = Regex::new("^[a-zA-Z_$]+[a-zA-Z1-9_$]*$").unwrap();
@@ -65,11 +72,26 @@ impl FromStr for TSIdent {
         if !REGEX_TS_IDENT.is_match(input) {
             return Err(IdentError::InvalidIdent(input.to_string()));
         }
+
+        Ok(TSIdent(input.to_string()))
+    }
+}
+
+impl FromStr for StrictTSIdent {
+    type Err = IdentError;
+
+    fn from_str(input: &str) -> Result<Self, IdentError> {
         if RESERVED.contains(&input.to_lowercase().as_str()) {
             return Err(IdentError::ReservedKeyword(input.to_string()));
         }
 
-        Ok(TSIdent(input.to_string()))
+        Ok(StrictTSIdent(TSIdent::from_str(input)?))
+    }
+}
+
+impl From<StrictTSIdent> for TSIdent {
+    fn from(source: StrictTSIdent) -> Self {
+        source.0
     }
 }
 
@@ -77,28 +99,43 @@ impl FromStr for TSIdent {
 pub mod tests {
     use super::*;
 
-    pub fn should_fail_when_ident_is_reserved_keyword() {
+    #[test]
+    pub fn should_work_when_ident_is_reserved_keyword() {
         assert_eq!(
             TSIdent::from_str("void"),
-            Err(IdentError::ReservedKeyword("void".to_string()))
+            Ok(TSIdent("void".to_string()))
         );
         assert_eq!(
             TSIdent::from_str("break"),
-            Err(IdentError::ReservedKeyword("void".to_string()))
+            Ok(TSIdent("break".to_string()))
         );
     }
 
+    #[test]
+    pub fn should_fail_when_strict_ident_is_reserved_keyword() {
+        assert_eq!(
+            StrictTSIdent::from_str("void"),
+            Err(IdentError::ReservedKeyword("void".to_string()))
+        );
+        assert_eq!(
+            StrictTSIdent::from_str("break"),
+            Err(IdentError::ReservedKeyword("break".to_string()))
+        );
+    }
+
+    #[test]
     pub fn should_fail_when_ident_is_invalid() {
         assert_eq!(
             TSIdent::from_str("2my_invalid_ident"),
-            Err(IdentError::InvalidIdent("void".to_string()))
+            Err(IdentError::InvalidIdent("2my_invalid_ident".to_string()))
         );
         assert_eq!(
-            TSIdent::from_str("break"),
-            Err(IdentError::ReservedKeyword("void".to_string()))
+            StrictTSIdent::from_str("break"),
+            Err(IdentError::ReservedKeyword("break".to_string()))
         );
     }
 
+    #[test]
     pub fn valid_ident() {
         assert_eq!(
             TSIdent::from_str("MyValidIdent"),

--- a/ts_json_subset/src/types.rs
+++ b/ts_json_subset/src/types.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::{
     common::{filters, BooleanLiteral, NumericLiteral, StringLiteral},
-    ident::TSIdent,
+    ident::{StrictTSIdent, TSIdent},
 };
 use askama::Template;
 use displaythis::Display;
@@ -115,7 +115,7 @@ pub enum TsType {
 #[template(source = "{{ name }}{{ args|display_opt }}", ext = "txt")]
 /// A type identifier with support for generic parameters
 pub struct TypeReference {
-    pub name: TSIdent,
+    pub name: StrictTSIdent,
     pub args: Option<TypeArguments>,
 }
 
@@ -243,7 +243,7 @@ pub mod tests {
         assert_eq!(
             PrimaryType::TypeReference(TypeReference {
                 args: None,
-                name: TSIdent::from_str("MyType").unwrap(),
+                name: StrictTSIdent::from_str("MyType").unwrap(),
             })
             .to_string(),
             "MyType"

--- a/typebinder/src/contexts/exporter.rs
+++ b/typebinder/src/contexts/exporter.rs
@@ -18,7 +18,7 @@ use syn::{GenericParam, Generics, ItemType};
 use ts_json_subset::{
     declarations::{interface::InterfaceDeclaration, type_alias::TypeAliasDeclaration},
     export::ExportStatement,
-    ident::{IdentError, TSIdent},
+    ident::{IdentError, StrictTSIdent, TSIdent},
     types::{
         IntersectionType, LiteralType, ObjectType, ParenthesizedType, PrimaryType, PropertyName,
         PropertySignature, TsType, TupleType, TypeBody, TypeMember, TypeParameter, TypeParameters,
@@ -142,7 +142,7 @@ impl ExporterContext<'_> {
         &self,
         type_alias: ItemType,
     ) -> Result<Solved<Vec<ExportStatement>>, TsExportError> {
-        let ident = TSIdent::from_str(&type_alias.ident.to_string())?;
+        let ident = StrictTSIdent::from_str(&type_alias.ident.to_string())?;
         let solver_info = TypeInfo {
             generics: &type_alias.generics,
             ty: type_alias.ty.as_ref(),
@@ -193,7 +193,7 @@ impl ExporterContext<'_> {
         if let Some(params) = type_params.as_mut() {
             apply_generic_constraints(params, &constraints);
         }
-        let ident = TSIdent::from_str(&ident)?;
+        let ident = StrictTSIdent::from_str(&ident)?;
         Ok(Solved {
             inner: vec![ExportStatement::InterfaceDeclaration(
                 InterfaceDeclaration {
@@ -226,7 +226,7 @@ impl ExporterContext<'_> {
         if let Some(params) = type_params.as_mut() {
             apply_generic_constraints(params, &solved.generic_constraints);
         }
-        let ident = TSIdent::from_str(&ident)?;
+        let ident = StrictTSIdent::from_str(&ident)?;
         Ok(solved.map(|inner_type| {
             vec![TypeAliasDeclaration {
                 ident,
@@ -267,7 +267,7 @@ impl ExporterContext<'_> {
         if let Some(params) = type_params.as_mut() {
             apply_generic_constraints(params, &constraints);
         }
-        let ident = TSIdent::from_str(&ident)?;
+        let ident = StrictTSIdent::from_str(&ident)?;
         Ok(Solved {
             inner: vec![TypeAliasDeclaration {
                 ident,
@@ -352,7 +352,7 @@ impl ExporterContext<'_> {
         if let Some(params) = type_params.as_mut() {
             apply_generic_constraints(params, &constraints);
         }
-        let ident = TSIdent::from_str(&ident)?;
+        let ident = StrictTSIdent::from_str(&ident)?;
         Ok(Solved {
             inner: vec![ExportStatement::TypeAliasDeclaration(
                 TypeAliasDeclaration {
@@ -456,7 +456,7 @@ impl ExporterContext<'_> {
         if let Some(params) = type_params.as_mut() {
             apply_generic_constraints(params, &constraints);
         }
-        let ident = TSIdent::from_str(&ident)?;
+        let ident = StrictTSIdent::from_str(&ident)?;
         Ok(Solved {
             inner: vec![TypeAliasDeclaration {
                 ident,
@@ -543,7 +543,7 @@ impl ExporterContext<'_> {
         if let Some(params) = type_params.as_mut() {
             apply_generic_constraints(params, &constraints);
         }
-        let ident = TSIdent::from_str(&ident)?;
+        let ident = StrictTSIdent::from_str(&ident)?;
         Ok(Solved {
             inner: vec![TypeAliasDeclaration {
                 ident,
@@ -658,7 +658,7 @@ impl ExporterContext<'_> {
         if let Some(params) = type_params.as_mut() {
             apply_generic_constraints(params, &constraints);
         }
-        let ident = TSIdent::from_str(&ident)?;
+        let ident = StrictTSIdent::from_str(&ident)?;
         Ok(Solved {
             inner: vec![TypeAliasDeclaration {
                 ident,

--- a/typebinder/src/type_solving/solvers/collections.rs
+++ b/typebinder/src/type_solving/solvers/collections.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use syn::Type;
 use ts_json_subset::{
-    ident::TSIdent,
+    ident::{StrictTSIdent, TSIdent},
     types::{ArrayType, PredefinedType, PrimaryType, TsType, TypeArguments, TypeReference},
 };
 
@@ -62,7 +62,7 @@ fn solve_map(
                     let first = solved.inner[0].clone();
                     let mut solved = solved.map(|inner| {
                         TsType::PrimaryType(PrimaryType::TypeReference(TypeReference {
-                            name: TSIdent::from_str("Record").unwrap(),
+                            name: StrictTSIdent::from_str("Record").unwrap(),
                             args: Some(TypeArguments {
                                 types: vec![inner[0].clone().into(), inner[1].clone().into()],
                             }),

--- a/typebinder/src/type_solving/solvers/generics.rs
+++ b/typebinder/src/type_solving/solvers/generics.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use syn::{GenericParam, Type};
 use ts_json_subset::{
-    ident::TSIdent,
+    ident::StrictTSIdent,
     types::{PrimaryType, TsType, TypeReference},
 };
 
@@ -44,7 +44,7 @@ impl TypeSolver for GenericsSolver {
             Some(ty) => SolverResult::Solved(Solved::new(TsType::PrimaryType(
                 PrimaryType::TypeReference(TypeReference {
                     args: None,
-                    name: TSIdent::from_str(&ty.ident.to_string()).unwrap(),
+                    name: StrictTSIdent::from_str(&ty.ident.to_string()).unwrap(),
                 }),
             ))),
             _ => SolverResult::Continue,

--- a/typebinder/src/type_solving/solvers/import.rs
+++ b/typebinder/src/type_solving/solvers/import.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use syn::{GenericArgument, Generics, PathArguments, Type, TypePath};
 use ts_json_subset::{
-    ident::TSIdent,
+    ident::StrictTSIdent,
     types::{
         PrimaryType, PropertyName, PropertySignature, TsType, TypeArguments, TypeMember,
         TypeReference,
@@ -142,7 +142,7 @@ pub fn solve_type_path(
     ty_path: TypePath,
 ) -> Result<Solved<TsType>, TsExportError> {
     let segment = ty_path.path.segments.last().expect("Empty path");
-    let ident = TSIdent::from_str(&segment.ident.to_string())?;
+    let ident = StrictTSIdent::from_str(&segment.ident.to_string())?;
     let mut imports: Vec<ImportEntry> = Vec::new();
     let mut constraints = GenericConstraints::default();
 


### PR DESCRIPTION
Fixes #23.

Implements a newtype `StrictTSIdent` that checks for reserved TS keywords, and use it where applicable (that is, a reserved keyword can not be use as an identifier for a type's name), so TSIdent had to go away from our "declarations" type.

Activates the test coverage on TSIdent (because it wasn't the case before, facepalm)