### PR TITLE
Initial implementation of Typebinder Checkmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,37 @@
-# Typebinder 
+# Typebinder
 
-Translate your Rust structures into TypeScript.  
+Translate your Rust structures into TypeScript.
 
-`typebinder` works as a library to integrate in your `build.rs` file, or as a CLI. A default CLI is available for your simple use-cases, `typebinder_cli`. 
+`typebinder` works as a library to integrate in your `build.rs` file, or as a CLI. A default CLI is available for your simple use-cases, `typebinder_cli`.
 
 Using `typebinder` will statically prevent desynchronizations between your front-end (provided that it runs on TypeScript) and your backend.
 
-## Features 
+## Features
 
 * Based on `serde`
 * Modular : define your own "hooks" to serialize your own custom types
 * Supports Structs, Enums (with serde tag variants) and type aliases, as described below
 
-## Usage 
-
-Launch the CLI using 
+## Usage
 
 ```
-typebinder_cli <path/to/mod.rs>
-``` 
+# Outputs your bindings to the `ts` folder
+typebinder_cli <path/to/mod.rs> generate -o <typescript_src>
+```
 
-## Example 
+```
+# Displays the generated bindings to stdout
+typebinder_cli <path/to/mod.rs> generate
+```
 
-### Structures 
+```
+# Checks that your bindings are up to date, synchronized with your Rust codebase
+typebinder_cli <path/to/mod.rs> check <typescript_src>
+```
+
+## Example
+
+### Structures
 
 ```rust
 #[derive(Serialize, Deserialize)]
@@ -54,7 +63,7 @@ export interface MyStruct {
 }
 ```
 
-### Enums 
+### Enums
 
 Enums are also supported, and all `serde` tag variants are supported.
 
@@ -143,7 +152,7 @@ Type alias are also supported.
 type ArrayOfNumbers = Vec<u32>;
 ```
 
-Will translate to 
+Will translate to
 
 ```typescript
 type ArrayOfNumbers = number[];
@@ -151,7 +160,7 @@ type ArrayOfNumbers = number[];
 
 ## Fair warning
 
-While the tool works and is being used in production at [Impero](https://impero.com), `typebinder` is still in development and might not be exactly feature-complete. **Codegen is hard**. 
+While the tool works and is being used in production at [Impero](https://impero.com), `typebinder` is still in development and might not be exactly feature-complete. **Codegen is hard**.
 
 ## Run tests
 
@@ -163,7 +172,7 @@ cargo test
 
 ### Integration tests
 
-This launches the unit tests and the test suite (see `typebinder_test_suite`) :  
+This launches the unit tests and the test suite (see `typebinder_test_suite`) :
 
 ```
 make test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Using `typebinder` will statically prevent desynchronizations between your front
 ## Usage
 
 ```
-# Outputs your bindings to the `ts` folder
+# Outputs your bindings to the `<typescript_src>` folder
 typebinder_cli <path/to/mod.rs> generate -o <typescript_src>
 ```
 

--- a/typebinder/Cargo.toml
+++ b/typebinder/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 [dependencies]
 syn = { version = "1.0" }
 proc-macro2 = "1.0"
+displaythis = "1.0"
 thiserror = "1.0"
 serde_derive_internals = "0.25"
 ts_json_subset = { path = "../ts_json_subset" }
@@ -17,6 +18,7 @@ log = "0.4"
 serde_json = "1.0"
 cargo_toml = "0.8"
 indexmap = "1.0"
+diff = "0.1.12"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/typebinder/src/exporters/check.rs
+++ b/typebinder/src/exporters/check.rs
@@ -1,0 +1,133 @@
+use crate::exporters::utils::{get_file_contents, get_output_file_path};
+use crate::{
+    error::TsExportError,
+    exporters::{Exporter, HeaderComment},
+    pipeline::module_step::ModuleStepResultData,
+};
+use displaythis::Display;
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::PathBuf;
+
+pub struct CheckExport {
+    root_path: PathBuf,
+    default_module_name: Option<String>,
+    header_comment: HeaderComment,
+    patches: HashMap<PathBuf, DiffPatch>,
+}
+
+impl Default for CheckExport {
+    fn default() -> Self {
+        let root_path = std::env::current_dir().expect("Failed to find current dir");
+        CheckExport {
+            root_path,
+            default_module_name: None,
+            header_comment: HeaderComment::Standard,
+            patches: HashMap::default(),
+        }
+    }
+}
+
+#[derive(Debug, Display)]
+pub enum DiffKind {
+    #[display("+{0}")]
+    Added(String),
+    #[display("-{0}")]
+    Removed(String),
+}
+
+#[derive(Debug, Display)]
+#[display("{line}: {kind}")]
+pub struct DiffChange {
+    line: usize,
+    kind: DiffKind,
+}
+
+#[derive(Debug)]
+pub enum DiffPatch {
+    NewFile(String),
+    Changes(Vec<DiffChange>),
+}
+
+pub fn display_patch((path, diff): (&PathBuf, &DiffPatch)) {
+    let path_str = path.to_str().expect("Path was not valid UTF8");
+    match diff {
+        DiffPatch::NewFile(contents) => {
+            log::error!(
+                "NEW MODULE {} DOES NOT EXIST IN THE BINDINGS YET:\n{}",
+                path_str,
+                contents
+            );
+        }
+        DiffPatch::Changes(changes) => {
+            log::error!("MODULE {} IS NOT CORRECT:", path_str);
+            changes.iter().for_each(|c| log::error!("{}", c));
+        }
+    }
+}
+
+impl CheckExport {
+    pub fn new(root_path: PathBuf) -> Self {
+        CheckExport {
+            root_path,
+            ..Default::default()
+        }
+    }
+}
+
+impl Exporter for CheckExport {
+    type Error = TsExportError;
+
+    fn export_module(&mut self, process_result: ModuleStepResultData) -> Result<(), TsExportError> {
+        let path =
+            get_output_file_path(&process_result, &self.default_module_name, &self.root_path);
+        log::info!("Comparing module at {:?}", path);
+
+        let generated_file_contents = get_file_contents(process_result, &self.header_comment);
+
+        match std::fs::File::open(&path) {
+            Ok(mut file) => {
+                let mut file_contents = String::new();
+                file.read_to_string(&mut file_contents)?;
+                let file_diff = diff::lines(&generated_file_contents, &file_contents);
+                let changes: Vec<DiffChange> = file_diff
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(|(line, dif)| match dif {
+                        diff::Result::Both(_, _) => None,
+                        diff::Result::Left(l) => Some(DiffChange {
+                            line,
+                            kind: DiffKind::Added(l.to_string()),
+                        }),
+                        diff::Result::Right(r) => Some(DiffChange {
+                            line,
+                            kind: DiffKind::Removed(r.to_string()),
+                        }),
+                    })
+                    .collect();
+                if !changes.is_empty() {
+                    self.patches.insert(path, DiffPatch::Changes(changes));
+                }
+
+                Ok(())
+            }
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::NotFound => {
+                    self.patches
+                        .insert(path, DiffPatch::NewFile(generated_file_contents));
+                    Ok(())
+                }
+                _ => Err(e.into()),
+            },
+        }
+    }
+
+    fn finish(self) {
+        self.patches.iter().for_each(display_patch);
+
+        let is_ok = self.patches.is_empty();
+        if !is_ok {
+            std::process::exit(1);
+        }
+    }
+}

--- a/typebinder/src/exporters/mod.rs
+++ b/typebinder/src/exporters/mod.rs
@@ -1,12 +1,49 @@
 //! How to output your bindings
-use crate::{error::TsExportError, pipeline::module_step::ModuleStepResultData};
+use crate::{
+    error::TsExportError, pipeline::module_step::ModuleStepResultData,
+    utils::display_path::DisplayPath,
+};
 
+pub mod check;
 pub mod file;
 pub mod stdout;
+pub mod utils;
 
 /// An abstraction that specifies the behaviour of how to handle a resulting process' data
 pub trait Exporter {
     type Error: Into<TsExportError>;
 
+    /// Consumes the process result to do something with it
     fn export_module(&mut self, process_result: ModuleStepResultData) -> Result<(), Self::Error>;
+
+    /// Called when the exporter's process is done
+    fn finish(self)
+    where
+        Self: Sized,
+    {
+    }
+}
+
+pub enum HeaderComment {
+    Standard,
+    Custom(String),
+    None,
+}
+
+impl HeaderComment {
+    pub fn render(&self, rust_module_path: &syn::Path) -> Option<String> {
+        match &self {
+            HeaderComment::None => None,
+            HeaderComment::Custom(comment) => Some(format!("/* {} */", comment)),
+            HeaderComment::Standard => {
+                let header = format!(
+                    "// This file was auto-generated with typebinder from Rust source code. Do not change this file manually.\n\
+                     // Change the Rust source code instead and regenerate with typebinder.\n\
+                     // Rust source module: {}",
+                     DisplayPath(&rust_module_path)
+                );
+                Some(header)
+            }
+        }
+    }
 }

--- a/typebinder/src/exporters/utils.rs
+++ b/typebinder/src/exporters/utils.rs
@@ -1,0 +1,52 @@
+use crate::exporters::HeaderComment;
+use crate::pipeline::module_step::ModuleStepResultData;
+
+use std::path::PathBuf;
+
+pub(crate) fn get_output_file_path(
+    process_result: &ModuleStepResultData,
+    default_module_name: &Option<String>,
+    root_path: &PathBuf,
+) -> PathBuf {
+    let mut file_path: PathBuf = if process_result.path.segments.is_empty() {
+        default_module_name
+            .clone()
+            .unwrap_or_else(|| "index".to_string())
+            .into()
+    } else {
+        process_result
+            .path
+            .segments
+            .iter()
+            .map(|segm| segm.ident.to_string())
+            .collect()
+    };
+    file_path.set_extension("ts");
+    let mut path = root_path.clone();
+    path.push(file_path);
+
+    path
+}
+
+pub(crate) fn get_file_contents(
+    process_result: ModuleStepResultData,
+    header_comment: &HeaderComment,
+) -> String {
+    let header = header_comment.render(&process_result.path);
+    let main_content: String = process_result
+        .imports
+        .into_iter()
+        .map(|statement| format!("{}\n", statement))
+        .chain(
+            process_result
+                .exports
+                .into_iter()
+                .map(|stm| format!("{}\n", stm.to_string())),
+        )
+        .collect();
+
+    match header {
+        None => main_content,
+        Some(comment) => format!("{}\n\n{}", comment, main_content),
+    }
+}

--- a/typebinder/src/pipeline/mod.rs
+++ b/typebinder/src/pipeline/mod.rs
@@ -17,7 +17,7 @@ pub mod step_result;
 /// A Pipeline is customized with both a [PipelineStepSpawner] and an [Exporter] implementor.
 ///
 /// When launched, the [Pipeline] will use its [PipelineStepSpawner] to spawn the "default" module, that is, the module with an empty path.
-/// Each [ModuleStep](crate::pipeline::module_step::ModuleStep) thereby generated is then launched, see [ModuleStep::launch](crate::pipeline::module_step::ModuleStep).  
+/// Each [ModuleStep](crate::pipeline::module_step::ModuleStep) thereby generated is then launched, see [ModuleStep::launch](crate::pipeline::module_step::ModuleStep).
 ///
 /// Each output is passed to the [Exporter], that is responsible for outputting the data.
 pub struct Pipeline<PSS, E> {
@@ -61,6 +61,8 @@ where
             }
             self.exporter.export_module(result_data)?;
         }
+
+        self.exporter.finish();
 
         Ok(())
     }

--- a/typebinder_cli/Cargo.toml
+++ b/typebinder_cli/Cargo.toml
@@ -11,3 +11,4 @@ license = "MIT"
 typebinder = { path = "../typebinder" }
 structopt = "0.3"
 pretty_env_logger = "0.4"
+log = "0.4"

--- a/typebinder_cli/src/main.rs
+++ b/typebinder_cli/src/main.rs
@@ -67,7 +67,7 @@ enum TypebinderCommand {
     /// Generates the bindings for your Rust files
     Generate {
         #[structopt(short, parse(from_os_str))]
-        /// Output path, will use stdout if no file is specified
+        /// Output path, will use stdout if no path is specified
         output: Option<PathBuf>,
     },
     /// Runs typebinder in "check" mode : no files will be produced.
@@ -78,7 +78,7 @@ enum TypebinderCommand {
     /// This mode is useful when you want to run typebinder in your CI pipeline.
     Check {
         #[structopt(parse(from_os_str))]
-        /// Output path where the bindings are generated
+        /// Output path where the bindings that we are checking against are stored
         output: PathBuf,
     },
 }


### PR DESCRIPTION
Implements #24.

Adds a CheckExport to be used anywhere, and an option to use it inside `typebinder_cli`.
Diff showing is homemade, couldn't find a crate that would display it properly... :shrug: 

Soon we'll be able to add this to the CI pipeline and conquer the world ! :) 