### PR TITLE
Support serde_json::Number in the solvers

### DIFF
--- a/typebinder/src/type_solving/solvers/primitives.rs
+++ b/typebinder/src/type_solving/solvers/primitives.rs
@@ -59,7 +59,8 @@ impl Default for PrimitivesSolver {
         inner.add_entry("i64", solver_number.clone());
         inner.add_entry("isize", solver_number.clone());
         inner.add_entry("f32", solver_number.clone());
-        inner.add_entry("f64", solver_number);
+        inner.add_entry("f64", solver_number.clone());
+        inner.add_entry("serde_json::Number", solver_number);
 
         inner.add_entry("char", solver_string.clone());
         inner.add_entry("str", solver_string.clone());


### PR DESCRIPTION
Adds support for `serde_json::Number` as a primitive that serializes to/from the `number` type in TS.

![image](https://user-images.githubusercontent.com/12024408/186349067-00969b54-fd9a-43d0-8c64-a977e3fb131f.png)
